### PR TITLE
Remove duplicate async cancellation

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -9,7 +9,6 @@ import psutil
 import time
 import subprocess
 import hashlib
-import requests
 import re
 import json
 from collections import defaultdict, deque
@@ -31,7 +30,6 @@ import zlib
 import backoff
 from urllib.parse import quote
 import aiofiles
-from logging import FileHandler
 from enum import Enum
 import idna
 from pybloom_live import ScalableBloomFilter
@@ -1129,7 +1127,7 @@ def get_system_resources() -> tuple[int, int, int]:
             max_jobs = 1
             batch_size = 5
             max_concurrent_dns = 5
-            log_once(logging.WARNING, f"Emergency-Mode: Batch-Größe=5, Jobs=1, DNS-Anfragen=5", console=True)
+            log_once(logging.WARNING, "Emergency-Mode: Batch-Größe=5, Jobs=1, DNS-Anfragen=5", console=True)
         elif global_mode == SystemMode.LOW_MEMORY:
             max_jobs = max(1, int(cpu_cores / (cpu_load + 0.1)) // 4)
             batch_size = max(5, min(20, int(free_memory / (1000 * 1024))))
@@ -1701,18 +1699,6 @@ Empfehlungen:
         logger.error(f"Kritischer Fehler in der Hauptfunktion: {e}")
         if global_mode != SystemMode.EMERGENCY:
             send_email("Kritischer Fehler im AdBlock-Skript", f"Skript fehlgeschlagen: {e}")
-        if cache_flush_task:
-            cache_flush_task.cancel()
-            try:
-                await cache_flush_task
-            except asyncio.CancelledError:
-                logger.debug("cache_flush_task erfolgreich abgebrochen")
-        if resource_monitor_task:
-            resource_monitor_task.cancel()
-            try:
-                await resource_monitor_task
-            except asyncio.CancelledError:
-                logger.debug("resource_monitor_task erfolgreich abgebrochen")
         sys.exit(1)
     finally:
         if cache_flush_task:


### PR DESCRIPTION
## Summary
- drop unused imports
- avoid empty f-string
- remove duplicate task cancellation code

## Testing
- `ruff check adblock.py`
- `black --check adblock.py` *(fails: would reformat)*
- `flake8 adblock.py` *(fails: E501 line too long)*
- `python adblock.py` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bce0bdd88833082a1d1da5993ebc1