### PR TITLE
Fix undefined MAX_DNS_CACHE_SIZE usage

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -34,6 +34,8 @@ from enum import Enum
 import idna
 from pybloom_live import ScalableBloomFilter
 
+from config import MAX_DNS_CACHE_SIZE
+
 
 class SystemMode(Enum):
     NORMAL = "normal"
@@ -1447,7 +1449,11 @@ def get_system_resources() -> tuple[int, int, int]:
             max_jobs = 1
             batch_size = 5
             max_concurrent_dns = 5
-            log_once(logging.WARNING, "Emergency-Mode: Batch-Größe=5, Jobs=1, DNS-Anfragen=5", console=True)
+            log_once(
+                logging.WARNING,
+                "Emergency-Mode: Batch-Größe=5, Jobs=1, DNS-Anfragen=5",
+                console=True,
+            )
         elif global_mode == SystemMode.LOW_MEMORY:
             max_jobs = max(1, int(cpu_cores / (cpu_load + 0.1)) // 4)
             batch_size = max(5, min(20, int(free_memory / (1000 * 1024))))
@@ -2330,7 +2336,9 @@ Empfehlungen:
     except Exception as e:
         logger.error(f"Kritischer Fehler in der Hauptfunktion: {e}")
         if global_mode != SystemMode.EMERGENCY:
-            send_email("Kritischer Fehler im AdBlock-Skript", f"Skript fehlgeschlagen: {e}")
+            send_email(
+                "Kritischer Fehler im AdBlock-Skript", f"Skript fehlgeschlagen: {e}"
+            )
         sys.exit(1)
     finally:
         if cache_flush_task:


### PR DESCRIPTION
## Summary
- import `MAX_DNS_CACHE_SIZE` from `config`
- use the imported constant for DNS cache pruning

## Testing
- `ruff check .`
- `black .`
- `flake8 .`
- `python adblock.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687be87073048330b1540a513782d192