### PR TITLE
Ensure newline at end of hosts_sources.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 !hosts.txt
 !requirements.txt
 !.flake8
+!hosts_sources.conf

--- a/hosts_sources.conf
+++ b/hosts_sources.conf
@@ -1,0 +1,2 @@
+https://adaway.org/hosts.txt
+https://v.firebog.net/hosts/Easyprivacy.txt


### PR DESCRIPTION
## Summary
- track new hosts_sources.conf in repository
- ensure hosts_sources.conf ends with a newline
- allow hosts_sources.conf via `.gitignore`

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `python adblock.py` *(fails: HTTP errors, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687e62b7f6248330a0efe0d939e940cc