### PR TITLE
Fix tests import path

### DIFF
--- a/tests/test_parse_domains.py
+++ b/tests/test_parse_domains.py
@@ -1,4 +1,14 @@
-from filter_engine import parse_domains
+"""Unit tests for domain parsing functions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on the module search path so local imports work
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from filter_engine import parse_domains  # noqa: E402
 
 
 def test_valid_domain_extraction():


### PR DESCRIPTION
## Summary
- add repo root to `sys.path` so tests can import modules when `pytest` is run directly

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f3e57dce48330b0f068911bb2961f