### PR TITLE
Fix DOMAIN_PATTERN newline issue

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,9 +13,7 @@ MAX_DNS_CACHE_SIZE = 10000
 
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
-DOMAIN_PATTERN = re.compile(
-    r"^(?:0\.0\.0\.0|127\.0\.0\.1|::1|[0-9a-fA-F:]+)\s+(\S+)|^\s*(\S+)|^\|\|([^\^]+)\^$"
-)
+DOMAIN_PATTERN = re.compile(r"^(?:0\.0\.0\.0|127\.0\.0\.1|::1|[0-9a-fA-F:]+)\s+(\S+)|^\s*(\S+)|^\|\|([^\^]+)\^$")
 DOMAIN_VALIDATOR = re.compile(
     r"^(?!-|\.)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"
 )


### PR DESCRIPTION
## Summary
- keep DOMAIN_PATTERN regex on one line in `config.py`

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `python adblock.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f5442e44c8330ac1531861bf1cf3c