### PR TITLE
Improve network error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ python adblock.py
 pip install -r requirements.txt
 ```
 
+## ❓ Troubleshooting
+
+Sollte das Laden der Blocklisten fehlschlagen, prüfe die Internetverbindung
+des Systems. Das Skript speichert eine Fehlermeldung in `statistics.json` unter
+`error_message`. Bei mehrfachen Fehlschlägen kann eine instabile Netzwerk-
+verbindung oder ein falsch konfigurierter Proxy die Ursache sein.
+
 ## 📄 Ausgabe
 
 Die Datei `hosts.txt` wird automatisch generiert.

--- a/adblock.py
+++ b/adblock.py
@@ -488,12 +488,16 @@ async def process_list(
         )
         return domain_count, unique_count, subdomain_count
     except aiohttp.ClientError as e:
-        logger.warning(f"Netzwerkfehler beim Verarbeiten der Liste {url}: {e}")
+        msg = f"Netzwerkfehler beim Verarbeiten der Liste {url}: {e}"
+        logger.warning(msg)
         STATISTICS["failed_lists"] += 1
+        STATISTICS["error_message"] = msg
         return 0, 0, 0
     except asyncio.TimeoutError as e:
-        logger.warning(f"Netzwerk-Timeout bei der Liste {url}: {e}")
+        msg = f"Netzwerk-Timeout bei der Liste {url}: {e}"
+        logger.warning(msg)
         STATISTICS["failed_lists"] += 1
+        STATISTICS["error_message"] = msg
         return 0, 0, 0
     except Exception as e:
         logger.error(f"Unbekannter Fehler beim Verarbeiten der Liste {url}: {e}")
@@ -635,6 +639,11 @@ async def main():
                     gc.collect()
         if not processed_urls:
             logger.warning("Keine gültigen Domains gefunden")
+            STATISTICS["error_message"] = (
+                "Alle Listen konnten nicht geladen werden. Bitte "
+                "Netzwerkverbindung überprüfen."
+            )
+            STATISTICS["run_failed"] = True
             if global_mode != SystemMode.EMERGENCY:
                 send_email(
                     "Fehler im AdBlock-Skript",


### PR DESCRIPTION
## Summary
- capture network errors and store informative messages
- mark job as failed if all lists fail
- mention networking troubleshooting steps in README
- fix ruff warning in networking utility

## Testing
- `ruff check . --fix`
- `black adblock.py networking.py`
- `flake8 .`
- `python adblock.py` *(fails to download lists due to unreachable network)*

------
https://chatgpt.com/codex/tasks/task_e_687f5d6b0f088330ae8201b929f409de