### PR TITLE
Add default host sources constant and tests

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -31,6 +31,7 @@ from caching import (
 from config import (
     DB_PATH,
     DEFAULT_CONFIG,
+    DEFAULT_HOST_SOURCES,
     LOG_FORMAT,
     REACHABLE_FILE,
     SCRIPT_DIR,
@@ -314,12 +315,7 @@ def initialize_directories_and_files():
             ("config.json", DEFAULT_CONFIG, True),
             (
                 "hosts_sources.conf",
-                "\n".join(
-                    [
-                        "https://adaway.org/hosts.txt",
-                        "https://v.firebog.net/hosts/Easyprivacy.txt",
-                    ]
-                ),
+                "\n".join(DEFAULT_HOST_SOURCES),
                 False,
             ),
             ("whitelist.txt", "# Whitelist für Domains, eine pro Zeile\n", False),

--- a/config.py
+++ b/config.py
@@ -13,6 +13,12 @@ MAX_DNS_CACHE_SIZE = 10000
 
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
+# Default sources used when no hosts_sources.conf file exists
+DEFAULT_HOST_SOURCES = [
+    "https://adaway.org/hosts.txt",
+    "https://v.firebog.net/hosts/Easyprivacy.txt",
+]
+
 DOMAIN_PATTERN = re.compile(r"^(?:0\.0\.0\.0|127\.0\.0\.1|::1|[0-9a-fA-F:]+)\s+(\S+)|^\s*(\S+)|^\|\|([^\^]+)\^$")
 DOMAIN_VALIDATOR = re.compile(
     r"^(?!-|\.)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"

--- a/source_loader.py
+++ b/source_loader.py
@@ -7,6 +7,7 @@ import os
 import logging
 
 from filter_engine import ist_gueltige_domain
+from config import DEFAULT_HOST_SOURCES
 
 
 def load_hosts_sources(
@@ -21,14 +22,7 @@ def load_hosts_sources(
                 sources_path,
             )
             with open(sources_path, "w", encoding="utf-8") as f:
-                f.write(
-                    "\n".join(
-                        [
-                            "https://adaway.org/hosts.txt",
-                            "https://v.firebog.net/hosts/Easyprivacy.txt",
-                        ]
-                    )
-                )
+                f.write("\n".join(DEFAULT_HOST_SOURCES))
         with open(sources_path, "r", encoding="utf-8") as f:
             sources = [
                 line.strip() for line in f if line.strip() and not line.startswith("#")

--- a/tests/test_default_sources.py
+++ b/tests/test_default_sources.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+import adblock  # noqa: E402
+from source_loader import load_hosts_sources  # noqa: E402
+from config import DEFAULT_HOST_SOURCES  # noqa: E402
+
+
+class DummyHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
+LOGGER = logging.getLogger("test_default_sources")
+LOGGER.addHandler(DummyHandler())
+
+
+def test_initialize_directories_creates_default_sources(tmp_path, monkeypatch):
+    monkeypatch.setattr(adblock, "SCRIPT_DIR", str(tmp_path))
+    monkeypatch.setattr(adblock, "TMP_DIR", str(tmp_path / "tmp"))
+    monkeypatch.setattr(adblock, "logger", LOGGER)
+
+    hosts_file = tmp_path / "hosts_sources.conf"
+    if hosts_file.exists():
+        hosts_file.unlink()
+
+    adblock.initialize_directories_and_files()
+
+    assert hosts_file.exists()
+    assert hosts_file.read_text().strip().splitlines() == DEFAULT_HOST_SOURCES
+
+
+def test_load_hosts_sources_uses_defaults(tmp_path, monkeypatch):
+    monkeypatch.setattr(adblock, "logger", LOGGER)
+    adblock.CONFIG.clear()
+    adblock.CONFIG.update(adblock.DEFAULT_CONFIG)
+    hosts_file = tmp_path / "hosts_sources.conf"
+    if hosts_file.exists():
+        hosts_file.unlink()
+
+    sources = load_hosts_sources(adblock.CONFIG, str(tmp_path), LOGGER)
+
+    assert hosts_file.exists()
+    assert sources == DEFAULT_HOST_SOURCES


### PR DESCRIPTION
## Summary
- add `DEFAULT_HOST_SOURCES` constant to `config.py`
- use `DEFAULT_HOST_SOURCES` in `initialize_directories_and_files` and `load_hosts_sources`
- test fallback to defaults when `hosts_sources.conf` is absent

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`
- `python adblock.py`

------
https://chatgpt.com/codex/tasks/task_e_6880bf18bb488330bc39bf1649ab5d15