### PR TITLE
Switch prints to logger

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -74,9 +74,10 @@ def log_once(level, message, console=True):
         logger.log(level, message)
         logged_messages.add(message)
     if console and message not in console_logged_messages:
-        print(
-            f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - {logging.getLevelName(level)} - {message}"
-        )
+        if level >= logging.ERROR:
+            logger.error(message)
+        else:
+            logger.info(message)
         console_logged_messages.add(message)
 
 
@@ -252,13 +253,15 @@ def setup_logging():
                 logger.error(
                     f"Fehler beim Erstellen des Log-Verzeichnisses {log_dir}: {e}"
                 )
-                print(f"Fehler beim Erstellen des Log-Verzeichnisses {log_dir}: {e}")
+                logger.error(
+                    f"Fehler beim Erstellen des Log-Verzeichnisses {log_dir}: {e}"
+                )
                 sys.exit(1)
             if not os.access(log_dir, os.W_OK):
                 logger.error(
                     f"Keine Schreibrechte für Log-Verzeichnis {log_dir}, beende Skript"
                 )
-                print(
+                logger.error(
                     f"Keine Schreibrechte für Log-Verzeichnis {log_dir}, beende Skript"
                 )
                 sys.exit(1)
@@ -296,7 +299,7 @@ def setup_logging():
         logger.debug(f"Logging konfiguriert mit Level {logging.getLevelName(level)}")
         logger.info("Logging erfolgreich konfiguriert")
     except Exception as e:
-        print(f"Fehler beim Einrichten des Loggings: {e}")
+        logger.error(f"Fehler beim Einrichten des Loggings: {e}")
         sys.exit(1)
 
 

--- a/tests/test_domain_trie.py
+++ b/tests/test_domain_trie.py
@@ -7,12 +7,14 @@ sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from adblock import DomainTrie  # noqa: E402
 import adblock  # noqa: E402
+import caching  # noqa: E402
 
 
 def test_insert_and_has_parent(tmp_path, monkeypatch):
     temp_dir = tmp_path / "tmp"
     temp_dir.mkdir()
     monkeypatch.setattr(adblock, "TMP_DIR", str(temp_dir))
+    monkeypatch.setattr(caching, "TMP_DIR", str(temp_dir), raising=False)
     adblock.CONFIG.clear()
     adblock.CONFIG.update(adblock.DEFAULT_CONFIG)
     trie = DomainTrie("test_url")


### PR DESCRIPTION
## Summary
- replace `print` usage in `adblock.log_once` and `setup_logging`
- patch domain trie test to update `TMP_DIR` for caching module

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c61e1904833088e87bcf62c2ef68