### PR TITLE
Cache-Flush-Lock lokal in main

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -63,7 +63,6 @@ class SystemMode(Enum):
 CONFIG = {}
 DNS_CACHE = {}
 dns_cache_lock = Lock()
-cache_flush_lock = asyncio.Lock()
 cache_manager = None
 global_mode = SystemMode.NORMAL
 
@@ -556,6 +555,7 @@ async def process_list(
 
 async def main(config_path: str | None = None, debug: bool = False):
     """Hauptfunktion des Skripts."""
+    cache_flush_lock = asyncio.Lock()
     cache_flush_task = None
     resource_monitor_task = None
     global cache_manager, global_mode


### PR DESCRIPTION
## Summary
- entferne die globale Deklaration von `cache_flush_lock`
- erstelle das Lock zu Beginn von `main`

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `python adblock.py`

------
https://chatgpt.com/codex/tasks/task_e_68855935f920833091accfc3bf9dfe61