### PR TITLE
Ersetze get_event_loop durch get_running_loop

### DIFF
--- a/monitoring.py
+++ b/monitoring.py
@@ -18,9 +18,9 @@ async def check_network_latency(config: dict) -> float:
         resolver = aiodns.DNSResolver(
             nameservers=[config["dns_servers"][0]], timeout=5.0
         )
-        start = asyncio.get_event_loop().time()
+        start = asyncio.get_running_loop().time()
         await resolver.query("example.com", "A")
-        latency = asyncio.get_event_loop().time() - start
+        latency = asyncio.get_running_loop().time() - start
         return latency
     except Exception:
         return float("inf")

--- a/networking.py
+++ b/networking.py
@@ -59,9 +59,9 @@ async def select_best_dns_server(
     async def test_server(server: str) -> Tuple[str, float]:
         try:
             resolver = aiodns.DNSResolver(nameservers=[server], timeout=timeout)
-            start = asyncio.get_event_loop().time()
+            start = asyncio.get_running_loop().time()
             await resolver.query("example.com", "A")
-            latency = asyncio.get_event_loop().time() - start
+            latency = asyncio.get_running_loop().time() - start
             return server, latency
         except Exception:
             return server, float("inf")


### PR DESCRIPTION
## Zusammenfassung
- aktuelle asyncio-API verwenden
- Netzwerk- und Monitoring-Module angepasst

## Testanweisungen
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `python adblock.py`

------
https://chatgpt.com/codex/tasks/task_e_688558c684f88330b15e44e9429070ae