### PR TITLE
Add pytest tests and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ __pycache__/
 *.pyc
 tmp/
 *.db
+!pytest.ini
+!tests/
+!tests/**

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ adblock.py      # Hauptskript
 hosts.txt       # Generierte Hostdatei
 ```
 
+## 🧪 Tests
+
+Die Tests werden mit `pytest` ausgeführt:
+
+```bash
+pytest
+```
+
 ## 📄 Lizenz
 
 MIT © CoYoDuDe

--- a/config.py
+++ b/config.py
@@ -19,7 +19,10 @@ DEFAULT_HOST_SOURCES = [
     "https://v.firebog.net/hosts/Easyprivacy.txt",
 ]
 
-DOMAIN_PATTERN = re.compile(r"^(?:0\.0\.0\.0|127\.0\.0\.1|::1|[0-9a-fA-F:]+)\s+(\S+)|^\s*(\S+)|^\|\|([^\^]+)\^$")
+DOMAIN_PATTERN = re.compile(
+    r"^(?:0\.0\.0\.0|127\.0\.0\.1|::1|[0-9a-fA-F:]+)\s+(?P<ip_domain>\S+)$|"
+    r"^\|\|(?P<adblock>[^\^]+)\^$|^(?P<plain>\S+)$"
+)
 DOMAIN_VALIDATOR = re.compile(
     r"^(?!-|\.)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"
 )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -ra

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from filter_engine import parse_domains  # noqa: E402
+
+
+def test_parse_domains_typical_lines():
+    content = """
+    0.0.0.0 example.com
+    ||ads.example.com^
+    # Kommentar
+    127.0.0.1    sub.example.com
+
+    ! weitere Kommentare
+    """
+    result = list(parse_domains(content, "dummy"))
+    assert result == ["example.com", "ads.example.com", "sub.example.com"]


### PR DESCRIPTION
## Summary
- ergänze pytest.ini zur einfachen Testausführung
- füge Tests für filter_engine hinzu
- verbessere DOMAIN_PATTERN, um Adblock-Format zu erkennen
- dokumentiere Tests im README
- aktualisiere .gitignore für Testdateien

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68855970529483309399250e930f9f4b