### PR TITLE
Implement DNS LRU cache

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -69,7 +69,6 @@ class SystemMode(Enum):
 
 
 CONFIG = {}
-DNS_CACHE = {}
 dns_cache_lock = Lock()
 cache_manager = None
 global_mode = SystemMode.NORMAL

--- a/networking.py
+++ b/networking.py
@@ -114,6 +114,9 @@ async def test_single_domain_async(
         return False
     if domain in blacklist:
         return True
+    cached_dns = cache_manager.get_dns_cache(domain)
+    if cached_dns is not None:
+        return cached_dns
     cache = cache_manager.load_domain_cache()
     if domain in cache:
         entry = cache[domain]
@@ -125,6 +128,7 @@ async def test_single_domain_async(
     reachable = await test_dns_entry_async(
         domain, resolver, max_concurrent=max_concurrent
     )
+    cache_manager.save_dns_cache(domain, reachable)
     cache_manager.save_domain(domain, reachable, url)
     return reachable
 


### PR DESCRIPTION
## Summary
- add `dns_cache` LRU-Cache in `caching.py`
- use `MAX_DNS_CACHE_SIZE` in `CacheManager` to manage the cache
- consult `dns_cache` before any DNS query
- store results in `dns_cache`
- remove unused `DNS_CACHE` from `adblock.py`

## Testing
- `ruff check .`
- `flake8 .`
- `black --check .`
- `python adblock.py --debug`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68856331b9148330a5b31a0620bbd927