### PR TITLE
Fix undefined DNS_CACHE usage

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -37,6 +37,7 @@ from caching import (
     CacheManager,
     DomainTrie,
     cleanup_temp_files,
+    dns_cache as DNS_CACHE,
 )
 from config import (
     DB_PATH,


### PR DESCRIPTION
## Summary
- import DNS cache constant from caching module
- ensure linter tests run cleanly

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885675e2f3c8330ad15ffdd217dca00