### PR TITLE
Add domain validation tests

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -750,7 +750,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                                     cache_manager,
                                     whitelist,
                                     blacklist,
-                                    DNS_CACHE,
+                                    cache_manager.dns_cache,
                                     dns_cache_lock,
                                     max_concurrent_dns,
                                 )
@@ -801,7 +801,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                             cache_manager,
                             whitelist,
                             blacklist,
-                            DNS_CACHE,
+                            cache_manager.dns_cache,
                             dns_cache_lock,
                             max_concurrent_dns,
                         )

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -2,7 +2,11 @@ from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from filter_engine import parse_domains  # noqa: E402
+from filter_engine import (  # noqa: E402
+    categorize_list,
+    ist_gueltige_domain,
+    parse_domains,
+)
 
 
 def test_parse_domains_typical_lines():
@@ -16,3 +20,28 @@ def test_parse_domains_typical_lines():
     """
     result = list(parse_domains(content, "dummy"))
     assert result == ["example.com", "ads.example.com", "sub.example.com"]
+
+
+def test_ist_gueltige_domain():
+    gueltige = [
+        "example.com",
+        "sub.domain.de",
+        "xn--d1acufc.xn--p1ai",  # IDN
+    ]
+    ungueltige = [
+        "-invalid.com",
+        "invalid-.de",
+        "no spaces.com",
+        "ex_ample.com",
+    ]
+    for domain in gueltige:
+        assert ist_gueltige_domain(domain)
+    for domain in ungueltige:
+        assert not ist_gueltige_domain(domain)
+
+
+def test_categorize_list():
+    assert categorize_list("https://malware.example.com/list.txt") == "malware"
+    assert categorize_list("https://ads.example.com/list.txt") == "ads"
+    assert categorize_list("https://porn.example.com/list.txt") == "adult"
+    assert categorize_list("https://unknown.example.com/list.txt") == "unknown"


### PR DESCRIPTION
## Summary
- add tests for domain validation and categorize_list
- fix undefined variable `DNS_CACHE` references

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885676414d083308a0f34074257a553