### PR TITLE
Add caching, source loader and networking tests

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -36,7 +36,6 @@ from caching import (
     CacheManager,
     DomainTrie,
     cleanup_temp_files,
-    dns_cache as DNS_CACHE,
 )
 import config
 from config import (
@@ -50,7 +49,6 @@ from config import (
     UNREACHABLE_FILE,
     CONFIG,
     dns_cache_lock,
-    DNS_CACHE,
     logged_messages,
     console_logged_messages,
 )
@@ -751,7 +749,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                                     config.cache_manager,
                                     whitelist,
                                     blacklist,
-                                    cache_manager.dns_cache,
+                                    config.cache_manager.dns_cache,
                                     dns_cache_lock,
                                     max_concurrent_dns,
                                 )
@@ -802,7 +800,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                             config.cache_manager,
                             whitelist,
                             blacklist,
-                            cache_manager.dns_cache,
+                            config.cache_manager.dns_cache,
                             dns_cache_lock,
                             max_concurrent_dns,
                         )

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import caching  # noqa: E402
+
+
+def test_domain_trie_insert_and_parent(monkeypatch, tmp_path):
+    monkeypatch.setattr(caching, "TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(caching, "TRIE_CACHE_PATH", str(tmp_path / "trie.pkl"))
+    config = caching.DEFAULT_CONFIG.copy()
+    config["use_bloom_filter"] = False
+    monkeypatch.setattr(caching, "DEFAULT_CONFIG", config)
+
+    trie = caching.DomainTrie("http://example.com")
+    trie.insert("example.com")
+    assert trie.has_parent("sub.example.com")
+    assert not trie.has_parent("example.com")
+    trie.flush()
+    assert not trie.has_parent("sub.example.com")
+    trie.close()
+
+
+def test_cache_manager_dns_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(caching, "TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(caching, "TRIE_CACHE_PATH", str(tmp_path / "trie.pkl"))
+    monkeypatch.setattr(caching, "DB_PATH", str(tmp_path / "cache.db"))
+    monkeypatch.setattr(caching, "MAX_DNS_CACHE_SIZE", 2)
+
+    cm = caching.CacheManager(str(tmp_path / "cache.db"), flush_interval=1)
+    cm.save_dns_cache("a.com", True)
+    cm.save_dns_cache("b.com", False)
+    assert cm.get_dns_cache("a.com") is True
+    assert cm.get_dns_cache("b.com") is False
+    cm.save_dns_cache("c.com", True)
+    assert "a.com" not in cm.dns_cache
+    cm.save_domain("a.com", True, "url")
+    cache = cm.load_domain_cache()
+    assert "a.com" in cache

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import networking  # noqa: E402
+
+
+def test_send_email_no_send(monkeypatch):
+    mock_smtp = MagicMock()
+    monkeypatch.setattr(networking, "smtplib", MagicMock(SMTP=mock_smtp))
+    networking.send_email("sub", "body", {"send_email": False})
+    assert not mock_smtp.called
+
+
+def test_send_email_via_smtp(monkeypatch):
+    mock_server = MagicMock()
+    smtp_instance = MagicMock(
+        __enter__=MagicMock(return_value=mock_server),
+        __exit__=MagicMock(return_value=None),
+    )
+    smtp_cls = MagicMock(return_value=smtp_instance)
+    monkeypatch.setattr(networking, "smtplib", MagicMock(SMTP=smtp_cls))
+    config = {
+        "send_email": True,
+        "use_smtp": True,
+        "email_sender": "a@b.com",
+        "email_recipient": "c@d.com",
+        "smtp_server": "srv",
+        "smtp_port": 25,
+        "smtp_user": "u",
+        "smtp_password": "p",
+    }
+    networking.send_email("sub", "body", config)
+    smtp_cls.assert_called_with("srv", 25)
+    mock_server.starttls.assert_called()
+    mock_server.login.assert_called_with("u", "p")
+    mock_server.send_message.assert_called()

--- a/tests/test_source_loader.py
+++ b/tests/test_source_loader.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+import logging
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import source_loader  # noqa: E402
+from config import DEFAULT_HOST_SOURCES  # noqa: E402
+
+
+def test_load_hosts_sources(tmp_path):
+    cfg = {"prioritize_lists": True, "priority_lists": ["https://prio.com"]}
+    file_path = tmp_path / "hosts_sources.conf"
+    file_path.write_text("https://normal.com\n#comment\nhttps://prio.com\n")
+    sources = source_loader.load_hosts_sources(
+        cfg, str(tmp_path), logging.getLogger("test")
+    )
+    assert sources[0] == "https://prio.com"
+    assert set(sources) == {"https://normal.com", "https://prio.com"}
+
+
+def test_load_hosts_sources_creates_default(tmp_path):
+    cfg = {"prioritize_lists": False, "priority_lists": []}
+    sources = source_loader.load_hosts_sources(
+        cfg, str(tmp_path), logging.getLogger("test")
+    )
+    assert (tmp_path / "hosts_sources.conf").exists()
+    assert set(sources) == set(DEFAULT_HOST_SOURCES)
+
+
+def test_load_whitelist_blacklist(tmp_path):
+    (tmp_path / "whitelist.txt").write_text("example.com\n#ignore\ninvalid_domain\n")
+    (tmp_path / "blacklist.txt").write_text("blocked.com\n")
+    wl, bl = source_loader.load_whitelist_blacklist(
+        str(tmp_path), logging.getLogger("test")
+    )
+    assert wl == {"example.com"}
+    assert bl == {"blocked.com"}


### PR DESCRIPTION
## Summary
- ensure DNS cache uses correct attribute
- add tests for `DomainTrie` and `CacheManager`
- add tests for host source and list loading utilities
- add tests for SMTP email handling

## Testing
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688570840ff083308e5abdaad742174a