### PR TITLE
dns_cache nach config verschoben

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -36,7 +36,6 @@ from caching import (
     CacheManager,
     DomainTrie,
     cleanup_temp_files,
-    dns_cache as DNS_CACHE,
 )
 import config
 from config import (
@@ -49,8 +48,8 @@ from config import (
     TMP_DIR,
     UNREACHABLE_FILE,
     CONFIG,
+    dns_cache,
     dns_cache_lock,
-    DNS_CACHE,
     logged_messages,
     console_logged_messages,
 )
@@ -66,6 +65,9 @@ from networking import (
 )
 from source_loader import load_hosts_sources, load_whitelist_blacklist
 from writer import safe_save, export_statistics_csv, export_prometheus_metrics
+
+# Referenz halten, um Linting-Fehler zu vermeiden
+_ = dns_cache
 
 
 class SystemMode(Enum):
@@ -751,7 +753,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                                     config.cache_manager,
                                     whitelist,
                                     blacklist,
-                                    cache_manager.dns_cache,
+                                    config.cache_manager.dns_cache,
                                     dns_cache_lock,
                                     max_concurrent_dns,
                                 )
@@ -802,7 +804,7 @@ async def main(config_path: str | None = None, debug: bool = False):
                             config.cache_manager,
                             whitelist,
                             blacklist,
-                            cache_manager.dns_cache,
+                            config.cache_manager.dns_cache,
                             dns_cache_lock,
                             max_concurrent_dns,
                         )

--- a/caching.py
+++ b/caching.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, Optional
 import psutil
 from pybloom_live import ScalableBloomFilter
 
-from collections import OrderedDict
 
 from config import (
     DEFAULT_CONFIG,
@@ -27,11 +26,10 @@ from config import (
     TRIE_CACHE_PATH,
     DB_PATH,
     MAX_DNS_CACHE_SIZE,
+    dns_cache,
 )
 
 logger = logging.getLogger(__name__)
-
-dns_cache: OrderedDict[str, bool] = OrderedDict()
 
 
 class HybridStorage:

--- a/config.py
+++ b/config.py
@@ -1,12 +1,14 @@
 import os
 import re
 from threading import Lock
+from collections import OrderedDict
 
 CONFIG = {}
 dns_cache_lock = Lock()
 cache_manager = None
 global_mode = None
 DNS_CACHE: dict[str, dict[str, float]] = {}
+dns_cache: OrderedDict[str, bool] = OrderedDict()
 logged_messages = set()
 console_logged_messages = set()
 


### PR DESCRIPTION
## Zusammenfassung
- verschiebe `dns_cache` aus `caching.py` nach `config.py`
- passe Importe in `caching.py` und `adblock.py` an
- importiere `dns_cache` aus `config` und bewahre Referenz

## Tests
- `ruff check . --fix`
- `black .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885707f538083308bbec7ecea173acd