### PR TITLE
Add reversible URL sanitizing for temporary files

### DIFF
--- a/caching.py
+++ b/caching.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional
 
 import psutil
 from pybloom_live import ScalableBloomFilter
+from urllib.parse import quote, unquote
 
 
 from config import (
@@ -30,6 +31,18 @@ from config import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def sanitize_tmp_identifier(url: str) -> str:
+    """Kodiert eine URL so, dass sie als Dateiname verwendet werden kann."""
+
+    return quote(url, safe="")
+
+
+def desanitize_tmp_filename(identifier: str) -> str:
+    """Rekonstruiert die ursprüngliche URL aus einem temporären Dateinamen."""
+
+    return unquote(identifier)
 
 
 class HybridStorage:
@@ -401,7 +414,8 @@ def cleanup_temp_files(cache_manager: CacheManager) -> None:
                 continue
 
             if file.endswith(".tmp") or file.endswith(".filtered"):
-                url = file.replace("__", "/").replace("_", "://")
+                sanitized_name, _ = os.path.splitext(file)
+                url = desanitize_tmp_filename(sanitized_name)
                 if url not in valid_urls:
                     os.remove(file_path)
     except Exception as exc:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import sys
+from datetime import datetime
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import caching  # noqa: E402
@@ -37,3 +38,22 @@ def test_cache_manager_dns_cache(monkeypatch, tmp_path):
     cm.save_domain("a.com", True, "url")
     cache = cm.load_domain_cache()
     assert "a.com" in cache
+
+
+def test_cleanup_temp_files_keeps_valid_filtered_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(caching, "TMP_DIR", str(tmp_path))
+    monkeypatch.setattr(caching, "TRIE_CACHE_PATH", str(tmp_path / "trie.pkl"))
+    monkeypatch.setattr(caching, "DB_PATH", str(tmp_path / "cache.db"))
+
+    cache_manager = caching.CacheManager(str(tmp_path / "cache.db"), flush_interval=1)
+    url = "https://example.com/list.txt"
+    cache_manager.save_list_cache(
+        {url: {"md5": "dummy", "last_checked": datetime.now().isoformat()}}
+    )
+    sanitized = caching.sanitize_tmp_identifier(url)
+    filtered_path = tmp_path / f"{sanitized}.filtered"
+    filtered_path.write_text("example.com\n", encoding="utf-8")
+
+    caching.cleanup_temp_files(cache_manager)
+
+    assert filtered_path.exists()


### PR DESCRIPTION
## Summary
- introduce shared helpers to sanitize and desanitize URLs for temporary cache filenames
- update adblock to rely on the helper instead of manual string replacement
- add a caching test to ensure cached filtered files are preserved during cleanup

## Testing
- ruff check . --fix
- black .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3df5bdaa88330b10bdfaeece33e4f