### PR TITLE
Pflege der Listenstatistiken und Exporte

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -66,14 +66,20 @@ def categorize_list(url: str) -> str:
         return "unknown"
 
 
-def evaluate_lists(url_counts: Dict[str, Dict], statistics: Dict, config: Dict) -> None:
+def evaluate_lists(statistics: Dict, config: Dict) -> None:
     """Evaluate list statistics and update metrics."""
     try:
-        for url, stats in statistics["list_stats"].items():
-            counts = url_counts.get(url, {"total": 0, "unique": 0, "subdomains": 0})
-            stats["total"] = counts["total"]
-            stats["unique"] = counts["unique"]
-            stats["subdomains"] = counts["subdomains"]
+        list_stats = statistics.get("list_stats", {})
+        for url, stats in list_stats.items():
+            stats.setdefault("total", 0)
+            stats.setdefault("unique", 0)
+            stats.setdefault("subdomains", 0)
+            stats.setdefault("reachable", 0)
+            stats.setdefault("unreachable", 0)
+            duplicates = stats.get("duplicates")
+            if duplicates is None:
+                duplicates = stats["total"] - stats["unique"]
+            stats["duplicates"] = max(duplicates, 0)
             stats["category"] = categorize_list(url)
             if stats["total"] > 0:
                 unique_ratio = stats["unique"] / stats["total"]

--- a/tests/test_statistics_exports.py
+++ b/tests/test_statistics_exports.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+import time
+from copy import deepcopy
+
+from config import DEFAULT_CONFIG
+from filter_engine import evaluate_lists
+from writer import export_prometheus_metrics, export_statistics_csv
+
+
+def test_statistics_exports_and_metrics(tmp_path):
+    statistics = {
+        "total_domains": 10,
+        "unique_domains": 8,
+        "reachable_domains": 6,
+        "unreachable_domains": 4,
+        "duplicates": 2,
+        "cache_hits": 0,
+        "cache_flushes": 0,
+        "trie_cache_hits": 0,
+        "failed_lists": 0,
+        "list_stats": {
+            "https://ads.example.com/hosts.txt": {
+                "total": 10,
+                "unique": 8,
+                "reachable": 6,
+                "unreachable": 2,
+                "duplicates": 2,
+                "subdomains": 1,
+                "score": 0.0,
+                "category": "unknown",
+            }
+        },
+    }
+
+    config = deepcopy(DEFAULT_CONFIG)
+    evaluate_lists(statistics, config)
+
+    assert statistics["list_stats"], "Es sollten Listeneinträge vorhanden sein."
+
+    csv_dir = tmp_path / "exports"
+    csv_dir.mkdir()
+    logger = logging.getLogger("adblock-test-logger")
+
+    export_statistics_csv(str(csv_dir), statistics, logger)
+    csv_content = (csv_dir / "statistics.csv").read_text(encoding="utf-8")
+    assert "https://ads.example.com/hosts.txt" in csv_content
+    assert ",6,2,2," in csv_content
+
+    start_time = time.time() - 5
+    export_prometheus_metrics(str(csv_dir), statistics, start_time, 42, logger)
+    metrics_content = (csv_dir / "metrics.prom").read_text(encoding="utf-8")
+
+    assert "adblock_list_total" in metrics_content
+    assert "adblock_list_unique" in metrics_content
+    assert "adblock_list_reachable" in metrics_content


### PR DESCRIPTION
## Summary
- erweitere die Verarbeitung in `adblock.py`, sodass Listeneinträge in `STATISTICS["list_stats"]` angelegt und während der DNS-Prüfung aktualisiert werden
- passe `evaluate_lists` an, damit es direkt auf den vollständig befüllten Statistikeinträgen arbeitet
- ergänze einen Test, der die erzeugten Statistiken sowie CSV- und Prometheus-Exporte überprüft

## Testing
- ruff check . --fix
- black .
- flake8 . *(nicht verfügbar in der Umgebung)*
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e3e1608fc88330a38869fc23f2ae08