### PR TITLE
Nutze gemeinsame Semaphore für DNS-Prüfungen

### DIFF
--- a/tests/test_adblock_statistics.py
+++ b/tests/test_adblock_statistics.py
@@ -10,7 +10,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import adblock  # noqa: E402
 import caching  # noqa: E402
 import config as config_module  # noqa: E402
-import pytest  # noqa: E402
 
 
 def test_ensure_list_stats_entry_initializes_and_updates(monkeypatch):


### PR DESCRIPTION
## Zusammenfassung
- Erzeuge eine gemeinsame `asyncio.Semaphore` im Domain-Batch und übergebe sie bis zu den DNS-Abfragen
- Ergänze einen Test mit zählendem Fake-Resolver, um die maximale Parallelität von DNS-Queries zu verifizieren
- Bereinige einen überflüssigen `pytest`-Import nach automatischer Lint-Korrektur

## Tests
- `ruff check . --fix`
- `black .`
- `flake8 .` *(fehlgeschlagen: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e3f579ffc083309162b603971f1aa2