### PR TITLE
Verbessere DomainTrie-Duplikaterkennung und Statistiktests

### DIFF
--- a/adblock.py
+++ b/adblock.py
@@ -519,7 +519,6 @@ async def process_list(
         unique_count = 0
         subdomain_count = 0
         duplicate_count = 0
-        seen_domains = set()
         batch = []
         async with aiofiles.open(
             temp_file, "w", encoding="utf-8"
@@ -542,11 +541,9 @@ async def process_list(
                         console=True,
                     )
                     await asyncio.sleep(5)
-                if domain in seen_domains:
+                if not trie.insert(domain):
                     duplicate_count += 1
                     continue
-                seen_domains.add(domain)
-                trie.insert(domain)
                 batch.append(domain)
                 domain_count += 1
                 if len(batch) >= batch_size:

--- a/tests/test_adblock_statistics.py
+++ b/tests/test_adblock_statistics.py
@@ -130,7 +130,7 @@ def test_process_list_cache_reuses_statistics(monkeypatch, tmp_path):
                 url, cache_manager, FakeSession("data")
             )
             duplicates_after_first = adblock.STATISTICS["duplicates"]
-            assert duplicates_after_first > 0
+            assert duplicates_after_first == 1
             assert result_first[2] > 0  # subdomain count
 
             result_second = await adblock.process_list(


### PR DESCRIPTION
## Summary
- erweitere `DomainTrie.insert`, sodass über den Bloom-Filter verifizierte Duplikate erkannt und als boolescher Rückgabewert gemeldet werden
- passe `adblock.process_list` an und nutze das Trie zur Duplikaterkennung ohne zusätzliches Set
- ergänze Tests für den neuen Kontrollfluss und sichere die unveränderte Statistikermittlung ab

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68e40b3eff908330b1857ccc5178c632