### PR TITLE
Implement deep merge for configuration overrides

### DIFF
--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,0 +1,33 @@
+import json
+from copy import deepcopy
+
+import pytest
+
+from adblock import CONFIG, load_config
+from config import DEFAULT_CONFIG
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    original = deepcopy(CONFIG)
+    try:
+        yield
+    finally:
+        CONFIG.clear()
+        CONFIG.update(original)
+
+
+def test_load_config_preserves_nested_defaults(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"resource_thresholds": {"low_memory_mb": 128}}),
+        encoding="utf-8",
+    )
+
+    load_config(str(config_path))
+
+    assert CONFIG["resource_thresholds"]["low_memory_mb"] == 128
+    assert (
+        CONFIG["resource_thresholds"]["emergency_memory_mb"]
+        == DEFAULT_CONFIG["resource_thresholds"]["emergency_memory_mb"]
+    )


### PR DESCRIPTION
## Summary
- add a recursive `deep_merge_dicts` helper for merging configuration dictionaries
- update `load_config` to merge defaults with custom overrides while preserving nested defaults
- add coverage ensuring partial overrides keep remaining `resource_thresholds` values

## Testing
- ruff check . --fix
- black adblock.py tests/test_config_loading.py
- flake8 .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e41437c040833092827aec04cb4dab