### PR TITLE
Inline-Kommentare beim Domain-Parsing ignorieren

### DIFF
--- a/filter_engine.py
+++ b/filter_engine.py
@@ -41,6 +41,13 @@ def parse_domains(content: str, url: str) -> Iterator[str]:
             line = line.strip()
             if not line or line.startswith(("#", "!")):
                 continue
+            for comment_symbol in ("#", "!"):
+                index = line.find(comment_symbol)
+                if index > 0:
+                    line = line[:index].strip()
+                    break
+            if not line:
+                continue
             match = DOMAIN_PATTERN.match(line)
             if match:
                 domain = (match.group(1) or match.group(2) or match.group(3)).lower()

--- a/tests/test_filter_engine.py
+++ b/tests/test_filter_engine.py
@@ -22,6 +22,15 @@ def test_parse_domains_typical_lines():
     assert result == ["example.com", "ads.example.com", "sub.example.com"]
 
 
+def test_parse_domains_with_inline_comment():
+    content = """
+    0.0.0.0 inline.example # Kommentar am Ende
+    ||tracking.example^ ! Zusätzlicher Kommentar
+    """
+    result = list(parse_domains(content, "dummy"))
+    assert result == ["inline.example", "tracking.example"]
+
+
 def test_ist_gueltige_domain():
     gueltige = [
         "example.com",


### PR DESCRIPTION
## Zusammenfassung
- Inline-Kommentare vor dem Regex-Match entfernen, damit Host- und Adblock-Zeilen korrekt erkannt werden
- Zusätzlichen Test ergänzt, der die Verarbeitung von Inline-Kommentaren bei Hosts- und Adblock-Syntax absichert

## Tests
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e5255d4cfc8330bcc5ab2a680d7d46