### PR TITLE
Korrigiere Statistik einzigartiger Domains

### DIFF
--- a/tests/test_unique_domains.py
+++ b/tests/test_unique_domains.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from adblock import calculate_unique_domains
+
+
+def test_calculate_unique_domains_prefers_global_set_for_duplicates():
+    url_counts = {
+        "https://example.com/list1": {"unique": 2},
+        "https://example.com/list2": {"unique": 2},
+    }
+    global_unique_domains = {"duplicate.example", "only-list1.example", "only-list2.example"}
+
+    assert calculate_unique_domains(url_counts, global_unique_domains) == 3
+
+
+def test_calculate_unique_domains_fallback_when_set_empty():
+    url_counts = {
+        "https://example.com/list1": {"unique": 5},
+        "https://example.com/list2": {"unique": 3},
+    }
+
+    assert calculate_unique_domains(url_counts, set()) == 8


### PR DESCRIPTION
## Zusammenfassung
- sammle Domains beim Einlesen der gefilterten Listen in einer globalen Menge und nutze sie zur Statistikberechnung
- ergänze die Hilfsfunktion `calculate_unique_domains`, um die konsolidierte Anzahl einzigartiger Domains zu bestimmen
- erweitere die Testsuite um Fälle für duplizierte Domains über mehrere Listen hinweg

## Tests
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e563c9cf8483308ee714856c29684e