### PR TITLE
Ensure domain statistics reflect deduplicated exports

### DIFF
--- a/tests/test_output_uniqueness.py
+++ b/tests/test_output_uniqueness.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 from pathlib import Path
 
 import adblock
@@ -56,3 +57,48 @@ def test_hosts_and_dnsmasq_outputs_are_unique(tmp_path, monkeypatch):
 
     assert len(dns_domains) == len(set(dns_domains))
     assert len(hosts_domains) == len(set(hosts_domains))
+
+
+def test_reachable_statistics_reflect_exported_lines(tmp_path, monkeypatch):
+    reachable_path = tmp_path / "reachable.txt"
+    reachable_path.write_text("duplicate.com\nsourcea.com\nduplicate.com\nsourceb.com\n")
+
+    config_copy = adblock.CONFIG.copy()
+    stats_copy = copy.deepcopy(adblock.STATISTICS)
+
+    monkeypatch.setattr(adblock, "CONFIG", config_copy)
+    monkeypatch.setattr(adblock, "STATISTICS", stats_copy)
+    monkeypatch.setattr(adblock, "REACHABLE_FILE", str(reachable_path))
+    monkeypatch.setattr(adblock, "SCRIPT_DIR", str(tmp_path))
+
+    config_copy.update(
+        {
+            "dns_config_file": "dnsmasq.conf",
+            "hosts_file": "hosts.txt",
+            "use_ipv4_output": True,
+            "use_ipv6_output": False,
+            "hosts_ip": "0.0.0.0",
+            "web_server_ipv4": "127.0.0.1",
+        }
+    )
+
+    stats_copy["reachable_domains"] = 999
+
+    sorted_domains = asyncio.run(
+        adblock.load_sorted_domains_with_statistics(str(reachable_path))
+    )
+
+    dns_lines = adblock.build_dnsmasq_lines(sorted_domains, config_copy, include_ipv6=False)
+    dns_path = Path(tmp_path) / config_copy["dns_config_file"]
+    dns_path.write_text("\n".join(dns_lines))
+
+    hosts_content = adblock.build_hosts_content(sorted_domains, config_copy)
+    hosts_path = Path(tmp_path) / config_copy["hosts_file"]
+    hosts_path.write_text(hosts_content)
+
+    exported_hosts_lines = [
+        line for line in hosts_path.read_text().splitlines() if line.strip()
+    ]
+
+    assert adblock.STATISTICS["reachable_domains"] == len(exported_hosts_lines)
+    assert adblock.STATISTICS["reachable_domains"] == len(dns_lines)


### PR DESCRIPTION
## Summary
- update reachable domain statistics to use the deduplicated sorted list and deduplicate exported unreachable domains
- add a regression test ensuring the reachable domain statistics match the exported hosts and dnsmasq line counts

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e56fb9561c833086d0c9085cf6e39b